### PR TITLE
Update version number on Geniventure branch to 0.1.0-gv.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "organelle",
-  "version": "0.0.1",
+  "version": "0.1.0-gv.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "organelle",
-  "version": "0.0.1",
+  "version": "0.1.0-gv.1",
   "description": "An agent-based modeling library based on SVG and declarative rules.",
+  "repository": "github:concord-consortium/organelle",
   "license": "MIT",
   "scripts": {
     "build": "npm-run-all clean build:production",


### PR DESCRIPTION
Update version number on Geniventure branch to 0.1.0-gv.1
- `0.1.0` to indicate that it's beyond the version from which it was branched (~0.0.11)
- `gv.1` prerelease tag to indicate Geniventure branch association
- add `repository` field to quiet npm warning